### PR TITLE
fixes to improve reusability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,18 @@ React app for AI image facial recognition processing.
 
 ## Getting started
 
-1. Clone the project & change into the new directory
+0. Clone the project & change into the new directory
 
 ```sh
 git clone https://github.com/dabit3/appsync-image-rekognition.git
 
 cd appsync-image-rekognition
+```
+
+1. Install dependencies 
+
+```sh
+npm install
 ```
 
 2. Initialize a new AWS Amplify project

--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,12 @@ class App extends Component {
             streamWidth: width,
             streamHeight: height
           })
-          video.src = window.URL.createObjectURL(stream);
+          // https://stackoverflow.com/questions/53626318/chrome-update-failed-to-execute-createobjecturl-on-url/53734174
+          try {
+            video.src = window.URL.createObjectURL(stream);
+          } catch (error) {
+            video.srcObject = stream;
+          }
           video.play();
       });
     }

--- a/src/index.js
+++ b/src/index.js
@@ -8,13 +8,15 @@ import Amplify from 'aws-amplify'
 import config from './aws-exports'
 import { Auth, Hub, Logger } from 'aws-amplify'
 
-Amplify.configure({
-  ...config,
-  'aws_appsync_graphqlEndpoint': 'https://bg7uqwbm6bcg7btr4f2p3n3hny.appsync-api.us-east-2.amazonaws.com/graphql',
-  'aws_appsync_region': 'us-east-1',
-  'aws_appsync_authenticationType': 'API_KEY',
-  'aws_appsync_apiKey': 'da2-upskhc6esfhobpzfposyu63mo4',
-})
+Amplify.configure(config)
+
+// Amplify.configure({
+//   ...config,
+//   'aws_appsync_graphqlEndpoint': 'https://bg7uqwbm6bcg7btr4f2p3n3hny.appsync-api.us-east-2.amazonaws.com/graphql',
+//   'aws_appsync_region': 'us-east-1',
+//   'aws_appsync_authenticationType': 'API_KEY',
+//   'aws_appsync_apiKey': 'da2-upskhc6esfhobpzfposyu63mo4',
+// })
 
 class AppWithAuth extends React.Component {
   state = {


### PR DESCRIPTION
You will find some minor fix that allow to run your sample project.  

- a minor change in the (for people like me that always forget `npm install`)
- a change required to run on Chrome 71.x (https://developers.google.com/web/updates/2018/10/chrome-71-deps-rems) 
- a change to use aws-export.js instead of a hard coded configuration.

Thanks for having build this demo ! 